### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For example:
                     |           └──────── 30 tokens
                     └──────────────────── key "ip-127.0.0.1"
 
-The command responds with an the number of tokens left in the bucket.
+The command responds with the number of tokens left in the bucket.
 `-1` is returned when the bucket is overflown.
 
     127.0.0.1:6379> SHIELD.absorb user123 30 60 13


### PR DESCRIPTION
Simply fixing a tiny typo in the Readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected a grammar/typo in the user-facing documentation: changed "an the number of tokens" to "the number of tokens".
  * Clarifies wording only; no functional, behavioral, or public API changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->