### PR TITLE
Upgrade rust to v1.95.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Project Essentials
 
-- **Language:** Rust Edition 2021, MSRV 1.91.1
+- **Language:** Rust Edition 2024, MSRV 1.95.0
 - **Platforms:** Linux (x86_64, aarch64), macOS (x86_64, aarch64)
 - **Core Files:** `src/lib.rs` (command handler), `src/bucket.rs` (token bucket algorithm)
 - **Performance:** 50K-55K req/s throughput, ~19µs latency per operation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thank you for your interest in contributing to Redis Shield! This document provi
 
 Redis Shield is a Redis loadable module written in Rust. Before contributing, make sure you have:
 
-- Rust toolchain 1.91.1 or later
+- Rust toolchain 1.95.0 or later
 - Redis server running locally
 - Basic understanding of Redis modules and the token bucket algorithm
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,7 @@
 name = "redis-shield"
 version = "1.0.0"
 authors = ["Alex Yarotsky <yarotsky.alex@gmail.com>"]
-edition = "2021"
-rust-version = "1.91.1"
+edition = "2024"
 description = "Redis module that implements the token bucket algorithm to do rate limiting as a native command"
 license = "MIT"
 readme = "README.md"

--- a/benches/README.md
+++ b/benches/README.md
@@ -5,7 +5,7 @@ This directory contains performance benchmarks for the Redis Shield rate limitin
 ## Prerequisites
 
 1. **Redis Server**: You must have a Redis server running with the Redis Shield module loaded
-2. **Rust**: Rust 1.91.1 or later
+2. **Rust**: Rust 1.95.0 or later
 3. **Environment Variable**: Set `REDIS_URL` to your Redis instance (defaults to `redis://127.0.0.1:6379`)
 
 ## Running Benchmarks

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.91.1"
+channel = "1.95.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines and documentation to require Rust 1.95.0 or later

* **Chores**
  * Upgraded Rust edition from 2021 to 2024
  * Updated minimum Rust version requirement to 1.95.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayarotsky/redis-shield/pull/97)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->